### PR TITLE
fix CORS errors with flask-cors

### DIFF
--- a/duplicate_finder.py
+++ b/duplicate_finder.py
@@ -37,6 +37,7 @@ import webbrowser
 import math
 
 from flask import Flask
+from flask_cors import CORS
 import imagehash
 from jinja2 import FileSystemLoader, Environment
 from more_itertools import chunked
@@ -261,6 +262,7 @@ def display_duplicates(duplicates, db):
         regex = '.*?'
 
     app = Flask(__name__)
+    CORS(app)
     app.url_map.converters['everything'] = EverythingConverter
 
     def render(duplicates, current, total):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ more-itertools==2.2
 pymongo==3.0.3
 termcolor==1.1.0
 Werkzeug==0.12.2
+Flask-Cors==3.0.3


### PR DESCRIPTION
Fixes #17 

Here's the error message: "Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'null' is therefore not allowed access."

Making requests to 127.0.0.1 from the local file is a cross-domain request and gets blocked by chrome. Adding flask-cors makes flask respond to the pre-flight checks and allows the cross-domain request.

Another way to fix this would be to serve up the images and template through flask (which might be noticably slower?).