### PR TITLE
Added ".idea" to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Trash
 .coverage
 .python-version
 **/__pycache__
+.idea


### PR DESCRIPTION
.idea directory is used in IntelliJ based IDEs from JetBrains, like
PyCharm, containing nothing which should be added to a general repo.